### PR TITLE
Resource fix modifier

### DIFF
--- a/game_lib/src/cards/properties/fix_cost.rs
+++ b/game_lib/src/cards/properties/fix_cost.rs
@@ -1,6 +1,9 @@
+use std::ops::Mul;
+
 use serde::{Deserialize, Serialize};
 
 use crate::cards::errors::{ErrorKind, ModelError};
+use crate::world::resource_fix_multiplier::ResourceFixMultiplier;
 use crate::world::resources::Resources;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -25,6 +28,17 @@ impl FixCost {
         }
     }
 
+    pub fn from_resources(min: Resources, max: Resources) -> Result<Self, ModelError> {
+        if min > max {
+            Err(ModelError {
+                kind: ErrorKind::Validation,
+                message: format!("min {:?} grater then max {:?}", min, max),
+            })
+        } else {
+            Ok(FixCost { min, max })
+        }
+    }
+
     pub fn min_value(&self) -> &usize {
         &self.min.value()
     }
@@ -39,6 +53,17 @@ impl Default for FixCost {
         FixCost {
             min: Resources::default(),
             max: Resources::default(),
+        }
+    }
+}
+
+impl Mul<&ResourceFixMultiplier> for FixCost {
+    type Output = Self;
+
+    fn mul(self, rhs: &ResourceFixMultiplier) -> Self::Output {
+        FixCost {
+            min: self.min * rhs,
+            max: self.max * rhs,
         }
     }
 }

--- a/game_lib/src/cards/properties/fix_modifier.rs
+++ b/game_lib/src/cards/properties/fix_modifier.rs
@@ -31,3 +31,14 @@ impl Mul<ResourceFixMultiplier> for FixModifier {
         }
     }
 }
+
+impl Mul<&ResourceFixMultiplier> for FixModifier {
+    type Output = Self;
+
+    fn mul(self, rhs: &ResourceFixMultiplier) -> Self::Output {
+        match self {
+            FixModifier::Increase(r) => FixModifier::Increase(r * rhs),
+            FixModifier::Decrease(r) => FixModifier::Decrease(r * rhs),
+        }
+    }
+}

--- a/game_lib/src/cards/properties/fix_modifier.rs
+++ b/game_lib/src/cards/properties/fix_modifier.rs
@@ -1,5 +1,8 @@
+use std::ops::Mul;
+
 use serde::{Deserialize, Serialize};
 
+use crate::world::resource_fix_multiplier::ResourceFixMultiplier;
 use crate::world::resources::Resources;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -14,6 +17,17 @@ impl FixModifier {
         match self {
             FixModifier::Increase(r) => r.value().clone() as isize,
             FixModifier::Decrease(r) => -1 * r.value().clone() as isize,
+        }
+    }
+}
+
+impl Mul<ResourceFixMultiplier> for FixModifier {
+    type Output = Self;
+
+    fn mul(self, rhs: ResourceFixMultiplier) -> Self::Output {
+        match self {
+            FixModifier::Increase(r) => FixModifier::Increase(r * rhs),
+            FixModifier::Decrease(r) => FixModifier::Decrease(r * rhs),
         }
     }
 }

--- a/game_lib/src/file/repository.rs
+++ b/game_lib/src/file/repository.rs
@@ -12,7 +12,7 @@ use crate::cards::types::lucky::LuckyCard;
 use crate::cards::types::oopsie::OopsieCard;
 use crate::errors::{ErrorKind, GameLibError, GameLibResult};
 use crate::file::cards::get_card_directory;
-use crate::file::general::{count_cards_in_directory, get_files_in_directory_with_filter};
+use crate::file::general::get_files_in_directory_with_filter;
 use crate::world::deck::{CardRc, DeckRepository};
 
 pub struct DeckLoader {

--- a/game_lib/src/world/board.rs
+++ b/game_lib/src/world/board.rs
@@ -20,7 +20,7 @@ pub struct CurrentBoard {
     pub current_resources: Resources,
     pub(crate) drawn_card: Option<CardRcWithId>,
     pub open_cards: HashMap<Uuid, CardRc>,
-    pub deck: Deck,
+    pub deck: Deck, // this should not be public, but is needed at the moment for game creation
     pub turns_remaining: usize,
 }
 
@@ -40,7 +40,7 @@ impl CurrentBoard {
         let current_resources = &self.current_resources;
         let deck = &self.deck;
         let cards = &self.deck.board;
-        let mut open_cards = &mut update_open_cards(self.open_cards.clone());
+        let open_cards = &mut update_open_cards(self.open_cards.clone());
         let (drawn_card, rest) = cards.split_at(1);
         let card_ref = Rc::new(drawn_card[0].clone());
         let card_id = Uuid::new_v4();
@@ -60,7 +60,7 @@ impl CurrentBoard {
     }
 
     pub(crate) fn close_card(&self, card_id: &Uuid) -> Self {
-        let mut open_cards = &mut self.open_cards.clone();
+        let open_cards = &mut self.open_cards.clone();
         open_cards.remove(card_id);
 
         CurrentBoard {

--- a/game_lib/src/world/game.rs
+++ b/game_lib/src/world/game.rs
@@ -11,6 +11,7 @@ use crate::cards::types::card_model::{Card, CardTrait};
 use crate::cards::types::oopsie::OopsieCard;
 use crate::world::board::CurrentBoard;
 use crate::world::deck::{CardRc, Deck};
+use crate::world::resource_fix_multiplier::ResourceFixMultiplier;
 use crate::world::resources::Resources;
 
 #[derive(Debug, Clone)]
@@ -33,6 +34,7 @@ pub struct Game {
     pub action_status: Option<ActionResult>,
     pub resource_gain: Resources,
     pub active_cards: HashMap<Uuid, CardRc>,
+    pub fix_multiplier: ResourceFixMultiplier,
     resource_effects: HashMap<Uuid, FixModifier>,
 }
 
@@ -57,7 +59,8 @@ impl Game {
             let res_effects = match modifier {
                 Some(m) => {
                     let mut new_resource_effects = self.resource_effects.clone();
-                    new_resource_effects.insert(card_id.clone(), m.clone());
+                    new_resource_effects
+                        .insert(card_id.clone(), m.clone() * self.fix_multiplier.clone());
                     new_resource_effects
                 }
                 None => self.resource_effects.clone(),
@@ -75,6 +78,7 @@ impl Game {
             resource_gain: self.resource_gain.clone(),
             action_status: self.action_status.clone(),
             active_cards: self.active_cards.clone(),
+            fix_multiplier: self.fix_multiplier.clone(),
         }
     }
 
@@ -100,7 +104,8 @@ impl Game {
                 match modifier {
                     None => {}
                     Some(m) => {
-                        new_resource_effects.insert(card_id.clone(), m.clone());
+                        new_resource_effects
+                            .insert(card_id.clone(), m.clone() * self.fix_multiplier.clone());
                     }
                 }
 
@@ -110,6 +115,7 @@ impl Game {
                     active_cards: new_active_cards,
                     action_status: self.action_status.clone(),
                     resource_gain: self.resource_gain.clone(),
+                    fix_multiplier: self.fix_multiplier.clone(),
                 }
             }
         }
@@ -128,6 +134,7 @@ impl Game {
             active_cards: new_active_cards,
             resource_gain: self.resource_gain.clone(),
             action_status: self.action_status.clone(),
+            fix_multiplier: self.fix_multiplier.clone(),
         }
     }
 
@@ -148,7 +155,7 @@ impl Game {
                 }
             }
             let value = increase as isize - decrease as isize;
-            if (value <= 0) {
+            if value <= 0 {
                 Some(FixModifier::Decrease(Resources::new(value.abs() as usize)))
             } else {
                 Some(FixModifier::Increase(Resources::new(value as usize)))
@@ -164,7 +171,11 @@ impl Game {
         }
     }
 
-    pub fn create(deck: Deck, initial_resource_gain: Resources) -> Self {
+    pub fn create(
+        deck: Deck,
+        initial_resource_gain: Resources,
+        fix_modifier: ResourceFixMultiplier,
+    ) -> Self {
         let board = CurrentBoard::init(deck, Resources::new(0));
         let status = GameStatus::Start(board);
 
@@ -174,6 +185,7 @@ impl Game {
             resource_gain: initial_resource_gain.clone(),
             resource_effects: HashMap::new(),
             active_cards: HashMap::new(),
+            fix_multiplier: fix_modifier,
         }
     }
 
@@ -198,7 +210,8 @@ impl Game {
                 Card::Event(c) => match &c.effect {
                     Effect::OnNextFix(_, m) => {
                         let mut new_resource_effect = self.resource_effects.clone();
-                        new_resource_effect.insert(card.id.clone(), m.clone());
+                        new_resource_effect
+                            .insert(card.id.clone(), m.clone() * self.fix_multiplier.clone());
                         new_resource_effect
                     }
                     _ => self.resource_effects.clone(),
@@ -215,6 +228,7 @@ impl Game {
             resource_gain: self.resource_gain.clone(),
             resource_effects,
             active_cards: HashMap::new(),
+            fix_multiplier: self.fix_multiplier.clone(),
         }
     }
 
@@ -226,13 +240,15 @@ impl Game {
                 resource_gain: new_gain,
                 resource_effects: self.resource_effects.clone(),
                 active_cards: self.active_cards.clone(),
+                fix_multiplier: self.fix_multiplier.clone(),
             },
-            GameStatus::Finished(board) => Game {
+            GameStatus::Finished(_) => Game {
                 status: self.status.clone(),
                 action_status: self.action_status.clone(),
                 resource_gain: self.resource_gain.clone(),
                 resource_effects: self.resource_effects.clone(),
                 active_cards: self.active_cards.clone(),
+                fix_multiplier: self.fix_multiplier.clone(),
             },
         }
     }
@@ -250,6 +266,7 @@ impl Game {
                         resource_gain: self.resource_gain.clone(),
                         resource_effects: self.resource_effects.clone(),
                         active_cards: self.active_cards.clone(),
+                        fix_multiplier: self.fix_multiplier.clone(),
                     };
                     Payment::Payed(game)
                 }
@@ -284,6 +301,7 @@ impl Game {
             resource_gain: self.resource_gain.clone(),
             resource_effects: self.resource_effects.clone(),
             active_cards: self.active_cards.clone(),
+            fix_multiplier: self.fix_multiplier.clone(),
         }
     }
 
@@ -292,9 +310,9 @@ impl Game {
             GameStatus::InProgress(board) => {
                 if let Some(card_to_close) = board.open_cards.get(card_id) {
                     match &**card_to_close {
-                        Card::Event(ec) => self.do_close_card(board, card_id),
+                        Card::Event(_) => self.do_close_card(board, card_id),
                         Card::Attack(ac) => self.close_attack_card(board, card_id, ac),
-                        Card::Oopsie(oc) => self.close_oopsie_card(board, card_id, oc),
+                        Card::Oopsie(oc) => self.close_oopsie_card(card_id, oc),
                         Card::Lucky(_) => self.do_close_card(board, card_id),
                     }
                 } else {
@@ -319,6 +337,7 @@ impl Game {
             resource_gain: self.resource_gain.clone(),
             resource_effects: new_resource_effects,
             active_cards: new_active_cards,
+            fix_multiplier: self.fix_multiplier.clone(),
         }
     }
 
@@ -336,14 +355,15 @@ impl Game {
                     resource_gain: game.resource_gain.clone(),
                     resource_effects: game.resource_effects.clone(),
                     active_cards: new_active_cards,
+                    fix_multiplier: self.fix_multiplier.clone(),
                 }
             }
             Duration::None => self.do_close_card(board, card_id),
         }
     }
 
-    fn close_oopsie_card(&self, board: &CurrentBoard, card_id: &Uuid, oc: &OopsieCard) -> Self {
-        let fix_cost = roll_dice_for_card(oc);
+    fn close_oopsie_card(&self, card_id: &Uuid, oc: &OopsieCard) -> Self {
+        let fix_cost = roll_dice_for_card(oc, self.fix_multiplier.clone());
         let actual_cost = if let Some(modifier) = self.get_current_fix_modifier() {
             match modifier {
                 FixModifier::Increase(r) => fix_cost + r,
@@ -384,12 +404,13 @@ impl Game {
             resource_gain: self.resource_gain.clone(),
             resource_effects: self.resource_effects.clone(),
             active_cards: self.active_cards.clone(),
+            fix_multiplier: self.fix_multiplier.clone(),
         }
     }
 }
 
-fn roll_dice_for_card(card: &OopsieCard) -> Resources {
+fn roll_dice_for_card(card: &OopsieCard, multiplier: ResourceFixMultiplier) -> Resources {
     let mut rng = thread_rng();
     let cost = rng.gen_range(card.fix_cost.min.value().clone()..card.fix_cost.max.value().clone());
-    Resources::new(cost)
+    Resources::new(cost) * multiplier
 }

--- a/game_lib/src/world/mod.rs
+++ b/game_lib/src/world/mod.rs
@@ -4,3 +4,4 @@ pub mod resources;
 pub mod result;
 
 pub mod game;
+pub mod resource_fix_multiplier;

--- a/game_lib/src/world/resource_fix_multiplier.rs
+++ b/game_lib/src/world/resource_fix_multiplier.rs
@@ -1,0 +1,23 @@
+use log::warn;
+
+#[derive(Clone, Debug, PartialOrd, PartialEq)]
+pub struct ResourceFixMultiplier(usize);
+
+impl ResourceFixMultiplier {
+    pub fn new(value: usize) -> Self {
+        if value < 1 {
+            warn!("Modifier must not be 0. Setting it to 1!")
+        }
+        ResourceFixMultiplier(value)
+    }
+
+    pub fn value(&self) -> &usize {
+        &self.0
+    }
+}
+
+impl Default for ResourceFixMultiplier {
+    fn default() -> Self {
+        ResourceFixMultiplier(1)
+    }
+}

--- a/game_lib/src/world/resources.rs
+++ b/game_lib/src/world/resources.rs
@@ -1,8 +1,9 @@
-use std::ops::{Add, Sub};
+use std::ops::{Add, Mul, Sub};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::cards::serialization::helper::Number;
+use crate::world::resource_fix_multiplier::ResourceFixMultiplier;
 
 #[derive(Clone, Debug, PartialOrd, PartialEq)]
 pub struct Resources(usize);
@@ -28,7 +29,7 @@ impl Sub for Resources {
     type Output = Resources;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        if (self.0 <= rhs.0) {
+        if self.0 <= rhs.0 {
             Resources::new(0)
         } else {
             Resources(self.0 - rhs.0)
@@ -68,5 +69,13 @@ impl Number for Resources {
 
     fn from_u64(value: u64) -> Self {
         Resources::new(value as usize)
+    }
+}
+
+impl Mul<ResourceFixMultiplier> for Resources {
+    type Output = Self;
+
+    fn mul(self, rhs: ResourceFixMultiplier) -> Self::Output {
+        Resources(self.0 * rhs.value())
     }
 }

--- a/game_lib/src/world/resources.rs
+++ b/game_lib/src/world/resources.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use std::ops::{Add, Mul, Sub};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -76,6 +77,14 @@ impl Mul<ResourceFixMultiplier> for Resources {
     type Output = Self;
 
     fn mul(self, rhs: ResourceFixMultiplier) -> Self::Output {
+        Resources(self.0 * rhs.value())
+    }
+}
+
+impl Mul<&ResourceFixMultiplier> for Resources {
+    type Output = Self;
+
+    fn mul(self, rhs: &ResourceFixMultiplier) -> Self::Output {
         Resources(self.0 * rhs.value())
     }
 }

--- a/gui/src/app.rs
+++ b/gui/src/app.rs
@@ -29,18 +29,21 @@ struct Input {
     next_res: String,
     pay_res: String,
     message: Message,
+    multiplier: String,
 }
 
 impl SecCardGameApp {
     fn init(deck: Deck) -> Self {
         let game = Game::create(deck, Resources::new(5), ResourceFixMultiplier::default());
         let initial_gain = game.resource_gain.value().clone();
+        let initial_multiplier = game.fix_multiplier.value().clone();
         Self {
             game,
             input: Input {
                 next_res: initial_gain.to_string(),
                 pay_res: "0".to_string(),
                 message: Message::None,
+                multiplier: initial_multiplier.to_string(),
             },
         }
     }
@@ -63,6 +66,7 @@ impl SecCardGameApp {
                 &card.0,
                 card.1.clone(),
                 self.game.active_cards.contains_key(&card.0),
+                self.game.fix_multiplier.clone(),
             );
             display_card(
                 &card_to_display,
@@ -149,6 +153,8 @@ impl SecCardGameApp {
 
                 ui.add_space(15.0);
 
+                self.tweak_control(ui);
+
                 ui.add_space(10.0);
                 match &self.game.status {
                     GameStatus::Start(board)
@@ -160,6 +166,7 @@ impl SecCardGameApp {
                         ));
                     }
                 }
+
                 ui.add_space(20.0);
                 match &self.input.message {
                     Message::Success(m) => Self::show_message(m, Color32::GREEN, ui),
@@ -172,6 +179,24 @@ impl SecCardGameApp {
 
     fn show_message(message: &String, color: Color32, ui: &mut Ui) {
         ui.label(RichText::new(message).color(color));
+    }
+
+    fn tweak_control(&mut self, ui: &mut Ui) {
+        ui.label("Tweaks");
+        ui.add_space(5.0);
+
+        ui.label("Mutliply all fix costs by:");
+        ui.horizontal(|ui| {
+            ui.text_edit_singleline(&mut self.input.multiplier);
+            ui.add_space(5.0);
+
+            if ui.button("Set Multiplier").clicked() {
+                let new_multiplier = self.input.multiplier.parse().unwrap_or_else(|_| 1);
+                self.game = self
+                    .game
+                    .set_fix_multiplier(ResourceFixMultiplier::new(new_multiplier));
+            }
+        });
     }
 
     fn resource_control(&mut self, ui: &mut Ui) {

--- a/gui/src/app.rs
+++ b/gui/src/app.rs
@@ -1,15 +1,13 @@
 use std::collections::HashMap;
-use std::fmt::{format, Display, Formatter};
 
 use egui::{Color32, Context, RichText, Ui};
-use rand::Rng;
 use uuid::Uuid;
 
 use game_lib::cards::properties::fix_modifier::FixModifier;
 use game_lib::world::board::CurrentBoard;
-use game_lib::world::deck::EventCards::Oopsie;
 use game_lib::world::deck::{CardRc, Deck};
 use game_lib::world::game::{ActionResult, Game, GameStatus, Payment};
+use game_lib::world::resource_fix_multiplier::ResourceFixMultiplier;
 use game_lib::world::resources::Resources;
 
 use crate::card_view_model::{CardContent, CardMarker};
@@ -33,14 +31,9 @@ struct Input {
     message: Message,
 }
 
-struct DiceRange {
-    min: String,
-    max: String,
-}
-
 impl SecCardGameApp {
     fn init(deck: Deck) -> Self {
-        let game = Game::create(deck, Resources::new(5));
+        let game = Game::create(deck, Resources::new(5), ResourceFixMultiplier::default());
         let initial_gain = game.resource_gain.value().clone();
         Self {
             game,

--- a/gui/src/card_view_model.rs
+++ b/gui/src/card_view_model.rs
@@ -1,8 +1,11 @@
+use std::ops::Add;
+
 use eframe::epaint::Color32;
 use uuid::Uuid;
 
 use game_lib::cards::properties::effect::Effect;
 use game_lib::cards::properties::fix_cost::FixCost;
+use game_lib::cards::properties::fix_modifier::FixModifier;
 use game_lib::cards::properties::target::Target;
 use game_lib::cards::types::attack::AttackCard;
 use game_lib::cards::types::card_model::{Card, CardTrait};
@@ -10,6 +13,7 @@ use game_lib::cards::types::event::EventCard;
 use game_lib::cards::types::lucky::LuckyCard;
 use game_lib::cards::types::oopsie::OopsieCard;
 use game_lib::world::deck::CardRc;
+use game_lib::world::resource_fix_multiplier::ResourceFixMultiplier;
 
 #[derive(Debug)]
 pub struct CardContent {
@@ -40,28 +44,39 @@ impl CardContent {
         card: Card,
         costs: Option<FixCost>,
         duration: Option<usize>,
+        multiplier: ResourceFixMultiplier,
     ) -> CardContent {
+        let actual_costs = match costs {
+            None => None,
+            Some(c) => Some(c * &multiplier),
+        };
+
         CardContent {
             id,
             dark_color,
             light_color,
             label: card.title().value().to_string(),
             description: card.description().value().to_string(),
-            action: Self::effect_to_text(&card.effect()),
+            action: Self::effect_to_text(&card.effect(), &multiplier),
             targets: Self::effect_to_targets(&card.effect()),
-            costs,
+            costs: actual_costs,
             duration,
             can_be_activated: Self::can_effect_be_activated(&card.effect()),
             card_marker: CardMarker::None,
         }
     }
 
-    pub fn from_card(id: &Uuid, card: CardRc, is_active: bool) -> CardContent {
+    pub fn from_card(
+        id: &Uuid,
+        card: CardRc,
+        is_active: bool,
+        multiplier: ResourceFixMultiplier,
+    ) -> CardContent {
         let mut card_view_model = match &*card {
-            Card::Event(c) => Self::event_card_content(id, c.clone()),
-            Card::Attack(c) => Self::incident_card_content(id, c.clone()),
-            Card::Oopsie(c) => Self::oopsie_card_content(id, c.clone()),
-            Card::Lucky(c) => Self::lucky_card_content(id, c.clone()),
+            Card::Event(c) => Self::event_card_content(id, c.clone(), multiplier),
+            Card::Attack(c) => Self::incident_card_content(id, c.clone(), multiplier),
+            Card::Oopsie(c) => Self::oopsie_card_content(id, c.clone(), multiplier),
+            Card::Lucky(c) => Self::lucky_card_content(id, c.clone(), multiplier),
         };
 
         card_view_model.card_marker = if is_active {
@@ -73,7 +88,11 @@ impl CardContent {
         card_view_model
     }
 
-    fn event_card_content(id: &Uuid, card: EventCard) -> CardContent {
+    fn event_card_content(
+        id: &Uuid,
+        card: EventCard,
+        multiplier: ResourceFixMultiplier,
+    ) -> CardContent {
         Self::new(
             id.clone(),
             Color32::LIGHT_BLUE,
@@ -81,6 +100,7 @@ impl CardContent {
             Card::Event(card),
             None,
             None,
+            multiplier,
         )
     }
 
@@ -104,14 +124,28 @@ impl CardContent {
         }
     }
 
-    fn effect_to_text(action: &Effect) -> String {
+    fn effect_to_text(action: &Effect, multiplier: &ResourceFixMultiplier) -> String {
         match action {
             Effect::Immediate(d) | Effect::Other(d) => d.value().to_string(),
-            Effect::OnNextFix(d, _)
-            | Effect::Incident(d, _)
-            | Effect::OnUsingForFix(d, _)
-            | Effect::AttackSurface(d, _) => d.value().to_string(),
+            Effect::OnNextFix(_d, m) => Self::modifier_to_text(m, multiplier).add(" on next fix."),
+            Effect::OnUsingForFix(_d, m) => {
+                Self::modifier_to_text(m, multiplier).add(" on use for a fix.")
+            }
+            Effect::Incident(d, _) | Effect::AttackSurface(d, _) => d.value().to_string(),
             Effect::NOP => "".to_string(),
+        }
+    }
+
+    fn modifier_to_text(fix_modifier: &FixModifier, multiplier: &ResourceFixMultiplier) -> String {
+        match fix_modifier {
+            FixModifier::Increase(r) => format!(
+                "Increase fix cost by {} resources",
+                (r.clone() * multiplier).value()
+            ),
+            FixModifier::Decrease(r) => format!(
+                "Decrease fix cost by {} resources",
+                (r.clone() * multiplier).value()
+            ),
         }
     }
 
@@ -119,7 +153,11 @@ impl CardContent {
         targets.iter().map(|i| i.value().to_string()).collect()
     }
 
-    fn incident_card_content(id: &Uuid, card: AttackCard) -> CardContent {
+    fn incident_card_content(
+        id: &Uuid,
+        card: AttackCard,
+        multiplier: ResourceFixMultiplier,
+    ) -> CardContent {
         let duration = card.duration.value().unwrap_or(&0).clone();
         Self::new(
             id.clone(),
@@ -128,10 +166,15 @@ impl CardContent {
             Card::Attack(card),
             None,
             Some(duration),
+            multiplier,
         )
     }
 
-    fn oopsie_card_content(id: &Uuid, card: OopsieCard) -> CardContent {
+    fn oopsie_card_content(
+        id: &Uuid,
+        card: OopsieCard,
+        multiplier: ResourceFixMultiplier,
+    ) -> CardContent {
         let fix_cost = &card.fix_cost.clone();
         Self::new(
             id.clone(),
@@ -140,10 +183,15 @@ impl CardContent {
             Card::Oopsie(card),
             Some(fix_cost.clone()),
             None,
+            multiplier,
         )
     }
 
-    fn lucky_card_content(id: &Uuid, card: LuckyCard) -> CardContent {
+    fn lucky_card_content(
+        id: &Uuid,
+        card: LuckyCard,
+        multiplier: ResourceFixMultiplier,
+    ) -> CardContent {
         Self::new(
             id.clone(),
             Color32::GREEN,
@@ -151,6 +199,7 @@ impl CardContent {
             Card::Lucky(card),
             None,
             None,
+            multiplier,
         )
     }
 }

--- a/gui/src/card_window.rs
+++ b/gui/src/card_window.rs
@@ -31,7 +31,7 @@ pub fn display_card<F, U>(
 }
 
 fn create_window<F, U>(
-    mut data: CardWindow,
+    data: CardWindow,
     close_callback: F,
     use_callback: U,
     ctx: &Context,


### PR DESCRIPTION
Adds a tweak section to the UI. This allows to set a fix cost multiplier which will multiply fix costs and also effects - if in the correct card format - by its value. Can be set during the game. This helps in playing around with different resource cost magnitues. E.g. setting it to 5 allows you to increase your roundly resource gain to a more sensible value (>3) where you can take 20% off.