### PR TITLE
37 add support for evaluation cards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "game_lib"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "fake",
  "log",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "game_ui"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "eframe",
  "egui",
@@ -2048,7 +2048,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seccardgame"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "cc",
  "clap",

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.5.7
+
+* [FEATURE] adds blank evaluation cards
+
 ## 0.5.6
 
 * [UPDATE] Updates dependencies, most notably egui

--- a/game_lib/Cargo.toml
+++ b/game_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "game_lib"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/game_lib/src/cards/types/attack.rs
+++ b/game_lib/src/cards/types/attack.rs
@@ -50,7 +50,6 @@ pub(crate) mod tests {
     use crate::cards::properties::description::tests::FakeDescription;
     use crate::cards::properties::duration::tests::FakeDuration;
     use crate::cards::properties::effect::Effect::Incident;
-    use crate::cards::properties::effect::tests::FakeEffect;
     use crate::cards::properties::effect_description::tests::FakeEffectDescription;
     use crate::cards::properties::target::tests::FakeTarget;
     use crate::cards::properties::title::tests::FakeTitle;

--- a/game_lib/src/cards/types/card_model.rs
+++ b/game_lib/src/cards/types/card_model.rs
@@ -4,6 +4,7 @@ use crate::cards::properties::description::Description;
 use crate::cards::properties::effect::Effect;
 use crate::cards::properties::title::Title;
 use crate::cards::types::attack::AttackCard;
+use crate::cards::types::evaluation::EvaluationCard;
 use crate::cards::types::event::EventCard;
 use crate::cards::types::lucky::LuckyCard;
 use crate::cards::types::oopsie::OopsieCard;
@@ -16,6 +17,7 @@ pub enum Card {
     Attack(AttackCard),
     Oopsie(OopsieCard),
     Lucky(LuckyCard),
+    Evaluation(EvaluationCard),
 }
 
 impl Card {
@@ -24,11 +26,14 @@ impl Card {
     pub const OOPSIE_CARD: &'static str = "Oopsie";
     pub const LUCKY_CARD: &'static str = "Lucky";
 
-    pub const CARD_TYPES: [&'static str; 4] = [
+    pub const EVALUATION: &'static str = "Evaluation";
+
+    pub const CARD_TYPES: [&'static str; 5] = [
         Self::ATTACK_CARD,
         Self::EVENT_CARD,
         Self::LUCKY_CARD,
         Self::OOPSIE_CARD,
+        Self::EVALUATION,
     ];
 }
 
@@ -48,6 +53,7 @@ impl CardTrait for Card {
             Card::Attack(card) => &card.title,
             Card::Oopsie(card) => &card.title,
             Card::Lucky(card) => &card.title,
+            Card::Evaluation(card) => &card.title,
         }
     }
 
@@ -57,6 +63,7 @@ impl CardTrait for Card {
             Card::Attack(card) => &card.description,
             Card::Oopsie(card) => &card.description,
             Card::Lucky(card) => &card.description,
+            Card::Evaluation(card) => &card.description,
         }
     }
 
@@ -66,6 +73,7 @@ impl CardTrait for Card {
             Card::Attack(card) => &card.effect,
             Card::Oopsie(card) => &card.effect,
             Card::Lucky(card) => &card.effect,
+            Card::Evaluation(card) => &card.effect,
         }
     }
 
@@ -75,6 +83,7 @@ impl CardTrait for Card {
             Card::Attack(_) => Card::ATTACK_CARD,
             Card::Oopsie(_) => Card::OOPSIE_CARD,
             Card::Lucky(_) => Card::LUCKY_CARD,
+            Card::Evaluation(_) => Card::EVALUATION,
         }
     }
 
@@ -84,6 +93,7 @@ impl CardTrait for Card {
             Card::Attack(_) => AttackCard::empty(),
             Card::Oopsie(_) => OopsieCard::empty(),
             Card::Lucky(_) => LuckyCard::empty(),
+            Card::Evaluation(_) => EvaluationCard::empty(),
         }
     }
 }
@@ -109,5 +119,11 @@ impl From<OopsieCard> for Card {
 impl From<AttackCard> for Card {
     fn from(value: AttackCard) -> Self {
         Card::Attack(value)
+    }
+}
+
+impl From<EvaluationCard> for Card {
+    fn from(value: EvaluationCard) -> Self {
+        Card::Evaluation(value)
     }
 }

--- a/game_lib/src/cards/types/evaluation.rs
+++ b/game_lib/src/cards/types/evaluation.rs
@@ -1,0 +1,53 @@
+use crate::cards::properties::description::Description;
+use crate::cards::properties::effect::Effect;
+use crate::cards::properties::title::Title;
+use crate::cards::types::card_model::Card;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct EvaluationCard {
+    pub title: Title,
+    pub description: Description,
+    pub effect: Effect,
+}
+
+impl Default for EvaluationCard {
+    fn default() -> Self {
+        EvaluationCard {
+            title: Title::from("Evaluation".to_string()),
+            description: Description::from("Be creative!".to_string()),
+            effect: Effect::NOP,
+        }
+    }
+}
+
+impl EvaluationCard {
+    pub fn empty() -> Card {
+        Card::Evaluation(EvaluationCard {
+            title: Title::empty(),
+            description: Description::empty(),
+            effect: Effect::NOP,
+        })
+    }
+
+    pub fn is_closeable(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use fake::Dummy;
+    use rand::Rng;
+
+    use super::*;
+
+    pub struct FakeEvaluationCard;
+
+    impl Dummy<FakeEvaluationCard> for EvaluationCard {
+        fn dummy_with_rng<R: Rng + ?Sized>(_: &FakeEvaluationCard, _: &mut R) -> Self {
+            EvaluationCard::default()
+        }
+    }
+}

--- a/game_lib/src/cards/types/mod.rs
+++ b/game_lib/src/cards/types/mod.rs
@@ -3,3 +3,4 @@ pub mod card_model;
 pub mod event;
 pub mod lucky;
 pub mod oopsie;
+pub mod evaluation;

--- a/game_lib/src/file/cards.rs
+++ b/game_lib/src/file/cards.rs
@@ -73,6 +73,7 @@ pub fn get_card_directory(card: &Card) -> &'static str {
         Card::Attack(_) => "attacks",
         Card::Oopsie(_) => "oopsies",
         Card::Lucky(_) => "lucky",
+        Card::Evaluation(_) => panic!("Evaluation cards should not be written to file"),
     }
 }
 

--- a/game_lib/src/world/actions/calculate_board.rs
+++ b/game_lib/src/world/actions/calculate_board.rs
@@ -51,6 +51,7 @@ fn get_modifier(
         Card::Attack(_) => None,
         Card::Oopsie(_) => None,
         Card::Lucky(l) => get_modifier_from_effect(&l.effect, cards_to_use.contains(card_id)),
+        Card::Evaluation(_) => None,
     }
 }
 

--- a/game_lib/src/world/actions/close_attack.rs
+++ b/game_lib/src/world/actions/close_attack.rs
@@ -20,7 +20,7 @@ pub fn update_attack_cards(board: Board) -> Board {
     for (key, card) in board.open_cards.iter() {
         let card_to_insert = match &**card {
             Card::Attack(ac) => update_attack_card(card, ac),
-            Card::Event(_) | Card::Oopsie(_) | Card::Lucky(_) => Some(card.clone()),
+            Card::Event(_) | Card::Oopsie(_) | Card::Lucky(_) | Card::Evaluation(_) => Some(card.clone()),
         };
 
         match card_to_insert {
@@ -68,7 +68,7 @@ fn update_attack_card(card: &CardRc, ac: &AttackCard) -> Option<Rc<Card>> {
 pub fn manually_close_attack_card(board: Board, card_id: &Uuid) -> ActionResult<Board> {
     if let Some(card) = board.open_cards.get(card_id) {
         match &**card {
-            Card::Oopsie(_) | Card::Lucky(_) | Card::Event(_) => Err(WrongCardType(board.clone())),
+            Card::Oopsie(_) | Card::Lucky(_) | Card::Event(_) | Card::Evaluation(_)=> Err(WrongCardType(board.clone())),
             Card::Attack(ac) => close_attack_card(&ac.duration.clone(), board, card_id),
         }
     } else {
@@ -116,6 +116,8 @@ mod tests {
     use crate::cards::types::lucky::tests::FakeLuckyCard;
     use crate::cards::types::oopsie::OopsieCard;
     use crate::cards::types::oopsie::tests::FakeOopsieCard;
+    use crate::cards::types::evaluation::EvaluationCard;
+    use crate::cards::types::evaluation::tests::FakeEvaluationCard;
     use crate::world::actions::action_error::ActionError;
     use crate::world::actions::close_attack::{manually_close_attack_card, update_attack_cards};
     use crate::world::board::Board;
@@ -189,6 +191,7 @@ mod tests {
     #[case::LuckyCard(Card::from(FakeLuckyCard.fake::<LuckyCard>()))]
     #[case::EventCard(Card::from(FakeEventCard.fake::<EventCard>()))]
     #[case::OopsieCard(Card::from(FakeOopsieCard.fake::<OopsieCard>()))]
+    #[case::OopsieCard(Card::from(FakeEvaluationCard.fake::<EvaluationCard>()))]
     fn update_attack_cards_does_not_affect_other_cards(#[case] card: Card) {
         let (_, board, _) = generate_board_with_open_card(card);
 
@@ -266,6 +269,7 @@ mod tests {
     #[case::LuckyCard(Card::from(FakeLuckyCard.fake::<LuckyCard>()))]
     #[case::EventCard(Card::from(FakeEventCard.fake::<EventCard>()))]
     #[case::OopsieCard(Card::from(FakeOopsieCard.fake::<OopsieCard>()))]
+    #[case::OopsieCard(Card::from(FakeEvaluationCard.fake::<EvaluationCard>()))]
     fn manually_close_attack_card_closes_card_returns_error_for_wrong_type(#[case] card: Card) {
         let (card_id, board, card_rc) = generate_board_with_open_card(card);
 

--- a/game_lib/src/world/actions/close_evaluation.rs
+++ b/game_lib/src/world/actions/close_evaluation.rs
@@ -1,0 +1,105 @@
+use uuid::Uuid;
+
+use crate::cards::types::card_model::Card;
+use crate::cards::types::evaluation::EvaluationCard;
+use crate::world::actions::action_error::ActionError::{InvalidState, WrongCardType};
+use crate::world::actions::action_error::ActionResult;
+use crate::world::board::Board;
+
+pub fn close_evaluation_card(board: Board, card_id: &Uuid) -> ActionResult<Board> {
+    if let Some(card) = board.open_cards.clone().get(card_id) {
+        match &**card {
+            Card::Evaluation(ec) => close_if_allowed(card_id, ec, board),
+            Card::Attack(_) | Card::Oopsie(_) | Card::Lucky(_) | Card::Event(_) => Err(WrongCardType(board)),
+        }
+    } else {
+        Err(InvalidState(board))
+    }
+}
+
+fn close_if_allowed(card_id: &Uuid, ec: &EvaluationCard, board: Board) -> ActionResult<Board> {
+    if ec.is_closeable() {
+        let open_cards = &mut board.open_cards.clone();
+        open_cards.remove(card_id);
+        Ok(Board {
+            open_cards: open_cards.clone(),
+            ..board
+        })
+    } else {
+        Err(InvalidState(board))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use fake::Fake;
+    use rstest::rstest;
+    use uuid::Uuid;
+
+    use crate::cards::properties::effect::Effect;
+    use crate::cards::types::attack::AttackCard;
+    use crate::cards::types::attack::tests::FakeAttackCard;
+    use crate::cards::types::card_model::Card;
+    use crate::cards::types::event::EventCard;
+    use crate::cards::types::event::tests::FakeEventCard;
+    use crate::cards::types::lucky::LuckyCard;
+    use crate::cards::types::lucky::tests::FakeLuckyCard;
+    use crate::cards::types::oopsie::OopsieCard;
+    use crate::cards::types::oopsie::tests::FakeOopsieCard;
+    use crate::cards::types::evaluation::EvaluationCard;
+    use crate::cards::types::evaluation::tests::FakeEvaluationCard;
+    use crate::world::actions::action_error::ActionError;
+    use crate::world::actions::close_evaluation::close_evaluation_card;
+    use crate::world::board::Board;
+    use crate::world::board::tests::generate_board_with_open_card;
+
+    #[test]
+    fn try_close_non_open_card() {
+        let (_, board, _) =
+            generate_board_with_open_card(Card::from(FakeEvaluationCard.fake::<EvaluationCard>()));
+
+        let expected_board = Board { ..board.clone() };
+
+        let result = close_evaluation_card(board, &Uuid::new_v4()).unwrap_err();
+
+        assert_eq!(result, ActionError::InvalidState(expected_board))
+    }
+
+    #[rstest]
+    #[case::LuckyCard(Card::from(FakeLuckyCard.fake::< LuckyCard > ()))]
+    #[case::AttackCard(Card::from(FakeAttackCard.fake::< AttackCard > ()))]
+    #[case::OopsieCard(Card::from(FakeOopsieCard.fake::< OopsieCard > ()))]
+    #[case::OopsieCard(Card::from(FakeEventCard.fake::<EventCard>()))]
+    fn try_close_wrong_card_type(#[case] card: Card) {
+        let (card_id, board, _) = generate_board_with_open_card(card);
+
+        let expected_board = Board { ..board.clone() };
+
+        let result = close_evaluation_card(board, &card_id).unwrap_err();
+
+        assert_eq!(result, ActionError::WrongCardType(expected_board));
+    }
+
+
+    #[test]
+    fn close_noop_effect() {
+        let evaluation_card = EvaluationCard {
+            effect: Effect::NOP,
+            ..FakeEvaluationCard.fake()
+        };
+        let card = Card::from(evaluation_card);
+
+        let (card_id, board, _) = generate_board_with_open_card(card);
+
+        let expected_board = Board {
+            open_cards: HashMap::new(),
+            ..board.clone()
+        };
+
+        let result = close_evaluation_card(board, &card_id).unwrap();
+
+        assert_eq!(result, expected_board);
+    }
+}

--- a/game_lib/src/world/actions/close_event.rs
+++ b/game_lib/src/world/actions/close_event.rs
@@ -10,7 +10,7 @@ pub fn close_event_card(board: Board, card_id: &Uuid) -> ActionResult<Board> {
     if let Some(card) = board.open_cards.clone().get(card_id) {
         match &**card {
             Card::Event(ec) => close_if_allowed(card_id, ec, board),
-            Card::Attack(_) | Card::Oopsie(_) | Card::Lucky(_) => Err(WrongCardType(board)),
+            Card::Attack(_) | Card::Oopsie(_) | Card::Lucky(_) | Card::Evaluation(_) => Err(WrongCardType(board)),
         }
     } else {
         Err(InvalidState(board))
@@ -50,6 +50,8 @@ mod tests {
     use crate::cards::types::lucky::tests::FakeLuckyCard;
     use crate::cards::types::oopsie::OopsieCard;
     use crate::cards::types::oopsie::tests::FakeOopsieCard;
+    use crate::cards::types::evaluation::EvaluationCard;
+    use crate::cards::types::evaluation::tests::FakeEvaluationCard;
     use crate::world::actions::action_error::ActionError;
     use crate::world::actions::close_event::close_event_card;
     use crate::world::board::Board;
@@ -71,6 +73,7 @@ mod tests {
     #[case::LuckyCard(Card::from(FakeLuckyCard.fake::< LuckyCard > ()))]
     #[case::AttackCard(Card::from(FakeAttackCard.fake::< AttackCard > ()))]
     #[case::OopsieCard(Card::from(FakeOopsieCard.fake::< OopsieCard > ()))]
+    #[case::OopsieCard(Card::from(FakeEvaluationCard.fake::<EvaluationCard>()))]
     fn try_close_wrong_card_type(#[case] card: Card) {
         let (card_id, board, _) = generate_board_with_open_card(card);
 

--- a/game_lib/src/world/actions/close_lucky.rs
+++ b/game_lib/src/world/actions/close_lucky.rs
@@ -10,7 +10,7 @@ pub fn close_lucky_card(board: Board, card_id: &Uuid) -> ActionResult<Board> {
     if let Some(card) = board.open_cards.clone().get(card_id) {
         match &**card {
             Card::Lucky(lc) => close_if_allowed(card_id, lc, board),
-            Card::Attack(_) | Card::Oopsie(_) | Card::Event(_) => Err(WrongCardType(board)),
+            Card::Attack(_) | Card::Oopsie(_) | Card::Event(_) | Card::Evaluation(_) => Err(WrongCardType(board)),
         }
     } else {
         Err(InvalidState(board))
@@ -41,11 +41,9 @@ mod tests {
     use rstest::rstest;
     use uuid::Uuid;
 
-    use crate::cards::properties::duration::Duration;
     use crate::cards::properties::effect::Effect;
     use crate::cards::properties::effect_description::tests::FakeEffectDescription;
     use crate::cards::properties::fix_modifier::tests::FakeFixModifier;
-    use crate::cards::properties::target::tests::FakeTarget;
     use crate::cards::types::attack::AttackCard;
     use crate::cards::types::attack::tests::FakeAttackCard;
     use crate::cards::types::card_model::Card;
@@ -55,6 +53,8 @@ mod tests {
     use crate::cards::types::lucky::tests::FakeLuckyCard;
     use crate::cards::types::oopsie::OopsieCard;
     use crate::cards::types::oopsie::tests::FakeOopsieCard;
+    use crate::cards::types::evaluation::EvaluationCard;
+    use crate::cards::types::evaluation::tests::FakeEvaluationCard;
     use crate::world::actions::action_error::ActionError;
     use crate::world::actions::close_lucky::close_lucky_card;
     use crate::world::board::Board;
@@ -76,6 +76,7 @@ mod tests {
     #[case::EventCard(Card::from(FakeEventCard.fake::< EventCard > ()))]
     #[case::AttackCard(Card::from(FakeAttackCard.fake::< AttackCard > ()))]
     #[case::OopsieCard(Card::from(FakeOopsieCard.fake::< OopsieCard > ()))]
+    #[case::OopsieCard(Card::from(FakeEvaluationCard.fake::<EvaluationCard>()))]
     fn try_close_wrong_card_type(#[case] card: Card) {
         let (card_id, board, _) = generate_board_with_open_card(card);
 

--- a/game_lib/src/world/actions/close_oopsie.rs
+++ b/game_lib/src/world/actions/close_oopsie.rs
@@ -28,7 +28,7 @@ pub fn try_and_pay_for_oopsie_fix(
 ) -> ActionResult<(Board, Resources)> {
     if let Some(card) = board.open_cards.get(card_id) {
         match &**card {
-            Card::Attack(_) | Card::Lucky(_) | Card::Event(_) => Err(WrongCardType(board.clone())),
+            Card::Attack(_) | Card::Lucky(_) | Card::Event(_) | Card::Evaluation(_) => Err(WrongCardType(board.clone())),
             Card::Oopsie(oc) => try_and_close(&board, card_id, oc, resource_fix_multiplier),
         }
     } else {
@@ -121,6 +121,8 @@ mod tests {
     use crate::cards::types::lucky::tests::FakeLuckyCard;
     use crate::cards::types::oopsie::OopsieCard;
     use crate::cards::types::oopsie::tests::FakeOopsieCard;
+    use crate::cards::types::evaluation::EvaluationCard;
+    use crate::cards::types::evaluation::tests::FakeEvaluationCard;
     use crate::world::actions::action_error::ActionError;
     use crate::world::actions::calculate_board::calculate_board;
     use crate::world::actions::close_oopsie::try_and_pay_for_oopsie_fix;
@@ -147,6 +149,7 @@ mod tests {
     #[case::LuckyCard(Card::from(FakeAttackCard.fake::<AttackCard>()))]
     #[case::EventCard(Card::from(FakeEventCard.fake::<EventCard>()))]
     #[case::OopsieCard(Card::from(FakeLuckyCard.fake::<LuckyCard>()))]
+    #[case::OopsieCard(Card::from(FakeEvaluationCard.fake::<EvaluationCard>()))]
     fn close_oopsie_card_returns_wrong_card_type_if_card_id_is_not_for_oopsie(#[case] card: Card) {
         let (card_id, board, _) = generate_board_with_open_card(card);
         let expected_board = board.clone();

--- a/game_lib/src/world/actions/mod.rs
+++ b/game_lib/src/world/actions/mod.rs
@@ -8,4 +8,5 @@ pub(crate) mod remove_resources;
 pub(crate) mod use_lucky_card;
 pub(crate) mod close_event;
 pub(crate) mod close_lucky;
+pub(crate) mod close_evaluation;
 

--- a/game_lib/src/world/actions/use_lucky_card.rs
+++ b/game_lib/src/world/actions/use_lucky_card.rs
@@ -19,7 +19,7 @@ where
 {
     if let Some(card) = board.open_cards.get(id) {
         match &**card {
-            Card::Event(_) | Card::Attack(_) | Card::Oopsie(_) => Err(WrongCardType(board)),
+            Card::Event(_) | Card::Attack(_) | Card::Oopsie(_) | Card::Evaluation(_) => Err(WrongCardType(board)),
             Card::Lucky(_) => Ok(func(board, id)),
         }
     } else {
@@ -63,6 +63,8 @@ mod tests {
     use crate::cards::types::lucky::tests::FakeLuckyCard;
     use crate::cards::types::oopsie::OopsieCard;
     use crate::cards::types::oopsie::tests::FakeOopsieCard;
+    use crate::cards::types::evaluation::EvaluationCard;
+    use crate::cards::types::evaluation::tests::FakeEvaluationCard;
     use crate::world::actions::action_error::ActionError;
     use crate::world::actions::use_lucky_card::{activate_lucky_card, deactivate_lucky_card};
     use crate::world::board::Board;
@@ -142,6 +144,7 @@ mod tests {
     #[case::AttackCard(Card::from(FakeAttackCard.fake::<AttackCard>()))]
     #[case::EventCard(Card::from(FakeEventCard.fake::<EventCard>()))]
     #[case::OopsieCard(Card::from(FakeOopsieCard.fake::<OopsieCard>()))]
+    #[case::OopsieCard(Card::from(FakeEvaluationCard.fake::<EvaluationCard>()))]
     fn activate_wrong_card_type(#[case] card: Card) {
         let card_rc = Rc::new(card.clone());
         let card_id = Uuid::new_v4();
@@ -243,6 +246,7 @@ mod tests {
     #[case::AttackCard(Card::from(FakeAttackCard.fake::<AttackCard>()))]
     #[case::EventCard(Card::from(FakeEventCard.fake::<EventCard>()))]
     #[case::OopsieCard(Card::from(FakeOopsieCard.fake::<OopsieCard>()))]
+    #[case::OopsieCard(Card::from(FakeEvaluationCard.fake::<EvaluationCard>()))]
     fn deactivate_wrong_card_type(#[case] card: Card) {
         let card_rc = Rc::new(card.clone());
         let card_id = Uuid::new_v4();

--- a/game_lib/src/world/deck.rs
+++ b/game_lib/src/world/deck.rs
@@ -53,6 +53,7 @@ pub struct DeckComposition {
     pub attacks: usize,
     pub oopsies: usize,
     pub lucky: usize,
+    pub evaluation: usize
 }
 
 impl From<EventCards> for Card {

--- a/game_lib/src/world/deck.rs
+++ b/game_lib/src/world/deck.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 use log::warn;
 use rand::{Rng, thread_rng};
-use rand::prelude::SliceRandom;
+use rand::prelude::{SliceRandom, ThreadRng};
 
 use crate::cards::types::attack::AttackCard;
 use crate::cards::types::card_model::Card;
@@ -111,9 +111,9 @@ impl DeckPreparation for PreparedDeck {
         let total_lucky_cards = access.get_lucky_cards().to_vec();
         let lucky_cards = draw_event_cards_for_deck(composition.lucky, total_lucky_cards);
         cards.append(&mut lucky_cards.clone());
-        
+
         let total_attack_cards = access.get_attack_cards().to_vec();
-        
+
         let evaluation_cards = (0..composition.evaluation).map(|_| EvaluationCard::default()).collect();
 
         PreparedDeck {
@@ -138,9 +138,17 @@ impl DeckPreparation for PreparedDeck {
         let event_cards = &self.cards;
         let attack_cards = &self.attacks;
         let mut cards: Vec<Card> = event_cards.iter().map(|c| c.clone().into()).collect();
-
         cards.shuffle(&mut rng);
 
+        let cards = Self::add_attack_cards(&mut rng, attack_graces, attack_cards, cards);
+        let cards = Self::add_evaluation_cards(&mut rng, &self.evaluation, cards);
+        
+        Deck::new(cards)
+    }
+}
+
+impl PreparedDeck {
+    fn add_attack_cards(mut rng: &mut ThreadRng, attack_graces: usize, attack_cards: &Vec<AttackCards>, cards: Vec<Card>) -> Vec<Card> {
         let (no_attack_cards, to_have_attack_cards) = cards.split_at(attack_graces);
 
         let mut part_with_attacks: Vec<Card> = to_have_attack_cards.to_vec();
@@ -152,10 +160,35 @@ impl DeckPreparation for PreparedDeck {
         );
         part_with_attacks.shuffle(&mut rng);
 
-        cards = no_attack_cards.to_vec().clone();
-        cards.extend(part_with_attacks);
-        Deck::new(cards)
+        let mut cards_without_attacks = no_attack_cards.to_vec().clone();
+        cards_without_attacks.extend(part_with_attacks);
+        cards_without_attacks
     }
+
+    /// This function inserts evaluation cards at regular intervals into a given vector of cards.
+    /// It divides the cards into chunks, adds an evaluation card to all chunks except the first,
+    /// shuffles the chunks with the new cards, and then consolidates them back into a single vector.
+    // TODO: Add a test for this method
+    fn add_evaluation_cards(mut rng: &mut ThreadRng, evaluation_cards: &Vec<EvaluationCard>, cards: Vec<Card>) -> Vec<Card> {
+        let eval_count = evaluation_cards.len();
+        let chunk_size = cards.len() / (eval_count + 1);
+        let chunks = cards.chunks(chunk_size);
+        
+        let mut cards = Vec::new();
+        for (i, chunk) in chunks.enumerate() {
+            if i == 0 {
+                cards.extend(chunk.to_vec());
+                continue
+            }
+            let mut chunk_with_eval = chunk.to_vec();
+            chunk_with_eval.push(evaluation_cards[i - 1].clone().into());
+            chunk_with_eval.shuffle(&mut rng);
+            cards.extend(chunk_with_eval)
+        }
+        
+        cards
+    }
+
 }
 
 fn draw_event_cards_for_deck(count: usize, cards_available: Vec<CardRc>) -> Vec<EventCards> {

--- a/game_lib/src/world/deck.rs
+++ b/game_lib/src/world/deck.rs
@@ -8,6 +8,9 @@ use crate::cards::types::card_model::Card;
 use crate::cards::types::event::EventCard;
 use crate::cards::types::lucky::LuckyCard;
 use crate::cards::types::oopsie::OopsieCard;
+use crate::cards::types::evaluation::EvaluationCard;
+
+
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Deck {
@@ -46,6 +49,7 @@ pub enum AttackCards {
 pub struct PreparedDeck {
     cards: Vec<EventCards>,
     attacks: Vec<AttackCards>,
+    evaluation: Vec<EvaluationCard>,
 }
 
 pub struct DeckComposition {
@@ -107,11 +111,15 @@ impl DeckPreparation for PreparedDeck {
         let total_lucky_cards = access.get_lucky_cards().to_vec();
         let lucky_cards = draw_event_cards_for_deck(composition.lucky, total_lucky_cards);
         cards.append(&mut lucky_cards.clone());
-
+        
         let total_attack_cards = access.get_attack_cards().to_vec();
+        
+        let evaluation_cards = (0..composition.evaluation).map(|_| EvaluationCard::default()).collect();
+
         PreparedDeck {
             cards,
             attacks: draw_attack_cards_for_deck(composition.attacks, total_attack_cards),
+            evaluation: evaluation_cards,
         }
     }
 
@@ -161,6 +169,7 @@ fn draw_event_cards_for_deck(count: usize, cards_available: Vec<CardRc>) -> Vec<
             Card::Attack(_) => {}
             Card::Oopsie(ref c) => cards.push(EventCards::Oopsie(c.clone())),
             Card::Lucky(ref c) => cards.push(EventCards::Lucky(c.clone())),
+            Card::Evaluation(_) => {},
         }
         x += 1;
     }

--- a/game_lib/src/world/game.rs
+++ b/game_lib/src/world/game.rs
@@ -224,6 +224,10 @@ impl Game {
             GameStatus::InProgress(board) => {
                 if let Some(card_to_close) = board.open_cards.get(card_id) {
                     match &**card_to_close {
+                        Card::Evaluation(_) => {
+                            // TODO: Implement close
+                            self.clone()
+                        }
                         Card::Attack(_) => self.handle_non_oopsie_close(
                             manually_close_attack_card(board.clone(), card_id),
                         ),

--- a/game_lib/src/world/game.rs
+++ b/game_lib/src/world/game.rs
@@ -8,6 +8,7 @@ use crate::world::actions::action_error::{ActionError, ActionResult};
 use crate::world::actions::add_resources::add_resources;
 use crate::world::actions::calculate_board::calculate_board;
 use crate::world::actions::close_attack::{manually_close_attack_card, update_attack_cards};
+use crate::world::actions::close_evaluation::close_evaluation_card;
 use crate::world::actions::close_event::close_event_card;
 use crate::world::actions::close_lucky::close_lucky_card;
 use crate::world::actions::close_oopsie::try_and_pay_for_oopsie_fix;
@@ -225,8 +226,7 @@ impl Game {
                 if let Some(card_to_close) = board.open_cards.get(card_id) {
                     match &**card_to_close {
                         Card::Evaluation(_) => {
-                            // TODO: Implement close
-                            self.clone()
+                            self.handle_non_oopsie_close(close_evaluation_card(board.clone(), card_id))
                         }
                         Card::Attack(_) => self.handle_non_oopsie_close(
                             manually_close_attack_card(board.clone(), card_id),
@@ -315,7 +315,7 @@ mod tests {
     use crate::cards::properties::fix_modifier::tests::FakeFixModifier;
     use crate::cards::types::attack::AttackCard;
     use crate::cards::types::attack::tests::FakeAttackCard;
-    use crate::cards::types::card_model::{Card, CardTrait};
+    use crate::cards::types::card_model::{Card};
     use crate::cards::types::event::EventCard;
     use crate::cards::types::event::tests::FakeEventCard;
     use crate::cards::types::lucky::LuckyCard;

--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "game_ui"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/gui/src/card_window/card_view_model.rs
+++ b/gui/src/card_window/card_view_model.rs
@@ -9,6 +9,7 @@ use game_lib::cards::properties::fix_modifier::FixModifier;
 use game_lib::cards::properties::target::Target;
 use game_lib::cards::types::attack::AttackCard;
 use game_lib::cards::types::card_model::{Card, CardTrait};
+use game_lib::cards::types::evaluation::EvaluationCard;
 use game_lib::cards::types::event::EventCard;
 use game_lib::cards::types::lucky::LuckyCard;
 use game_lib::cards::types::oopsie::OopsieCard;
@@ -80,6 +81,7 @@ impl CardContent {
             Card::Attack(c) => Self::incident_card_content(id, c.clone(), multiplier),
             Card::Oopsie(c) => Self::oopsie_card_content(id, c.clone(), multiplier),
             Card::Lucky(c) => Self::lucky_card_content(id, c.clone(), multiplier),
+            Card::Evaluation(c) => Self::evaluation_card_content(id, c.clone(), multiplier),
         };
 
         card_view_model.card_marker = if is_active {
@@ -205,6 +207,24 @@ impl CardContent {
             Color32::GREEN,
             Color32::DARK_GREEN,
             Card::Lucky(card),
+            None,
+            None,
+            can_be_closed,
+            multiplier,
+        )
+    }
+
+    fn evaluation_card_content(
+        id: &Uuid,
+        card: EvaluationCard,
+        multiplier: ResourceFixMultiplier,
+    ) -> CardContent {
+        let can_be_closed = card.is_closeable();
+        Self::new(
+            id.clone(),
+            Color32::GREEN,
+            Color32::DARK_GREEN,
+            Card::Evaluation(card),
             None,
             None,
             can_be_closed,

--- a/gui/src/card_window/card_view_model.rs
+++ b/gui/src/card_window/card_view_model.rs
@@ -222,8 +222,8 @@ impl CardContent {
         let can_be_closed = card.is_closeable();
         Self::new(
             id.clone(),
-            Color32::GREEN,
-            Color32::DARK_GREEN,
+            Color32::LIGHT_GRAY,
+            Color32::DARK_GRAY,
             Card::Evaluation(card),
             None,
             None,

--- a/seccardgame/Cargo.toml
+++ b/seccardgame/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seccardgame"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/seccardgame/src/cards/crud.rs
+++ b/seccardgame/src/cards/crud.rs
@@ -76,6 +76,7 @@ fn deserialize_editor_content(content: String, original_card: &Card) -> serde_js
         Card::Attack(_) => serde_json::from_str(content.as_str()).map(|c| Card::Attack(c)),
         Card::Oopsie(_) => serde_json::from_str(content.as_str()).map(|c| Card::Oopsie(c)),
         Card::Lucky(_) => serde_json::from_str(content.as_str()).map(|c| Card::Lucky(c)),
+        Card::Evaluation(_) => panic!("Cannot deserialize evaluation card"),
     }
 }
 

--- a/seccardgame/src/cards/crud.rs
+++ b/seccardgame/src/cards/crud.rs
@@ -83,14 +83,16 @@ fn deserialize_editor_content(content: String, original_card: &Card) -> serde_js
 pub fn create(cfg: &Config) -> CliResult<()> {
     print_stats(cfg)?;
     println!();
+    let creatable_card_types: Vec<&&str> = Card::CARD_TYPES.iter().filter(|i| i.ne(&&Card::EVALUATION)).collect();
+    
     let card_type_index = Select::new()
         .with_prompt("Select a card type to create")
-        .items(&Card::CARD_TYPES)
+        .items(&creatable_card_types)
         .default(0)
         .interact()
         .unwrap();
 
-    let card = match Card::CARD_TYPES[card_type_index] {
+    let card = match *creatable_card_types[card_type_index] {
         Card::EVENT_CARD => create_event_card(),
         Card::ATTACK_CARD => create_attack_card(),
         Card::LUCKY_CARD => create_lucky_card(),

--- a/seccardgame/src/game/create.rs
+++ b/seccardgame/src/game/create.rs
@@ -13,26 +13,30 @@ use crate::cli::cli_result::{CliError, CliResult, ErrorKind};
 use crate::cli::config::Config;
 
 fn get_number_of_cards(prompt: &str, default: u8) -> u8 {
-    Input::new().with_prompt(prompt)
+    Input::new()
+        .with_prompt(prompt)
         .default(default)
-        .interact().unwrap()
+        .interact()
+        .unwrap()
 }
 
 pub fn create_deck(config: &Config) -> Deck {
     let event_card_count = get_number_of_cards("Enter number of event types", 10);
     let attack_card_count = get_number_of_cards("Enter number of attack types", 5);
     let oopsie_card_count = get_number_of_cards("Enter number of oopsies", 15);
-    let lucky_card_count = get_number_of_cards("Enter number of lucky types",5);
-    let grace_period = get_number_of_cards("Enter number of turns after which attacks should be possible?",
-                                           (event_card_count + attack_card_count + oopsie_card_count + lucky_card_count) / 4
+    let lucky_card_count = get_number_of_cards("Enter number of lucky types", 5);
+    let grace_period = get_number_of_cards(
+        "Enter number of turns after which attacks should be possible?",
+        (event_card_count + attack_card_count + oopsie_card_count + lucky_card_count) / 4,
     );
-
+    let evaluation_cards = get_number_of_cards("Enter number of evaluation cards. The deck will be split into n + 1 parts and all parts except the first will contain an evaluation card. 0 disables them.", 0);
 
     let deck_composition = DeckComposition {
         events: event_card_count as usize,
         attacks: attack_card_count as usize,
         oopsies: oopsie_card_count as usize,
         lucky: lucky_card_count as usize,
+        evaluation: evaluation_cards as usize,
     };
 
     let prepared_deck = PreparedDeck::prepare(
@@ -40,8 +44,7 @@ pub fn create_deck(config: &Config) -> Deck {
         DeckLoader::create(config.game_path.as_str()),
     );
 
-    prepared_deck.shuffle(grace_period as usize
-    )
+    prepared_deck.shuffle(grace_period as usize)
 }
 
 pub fn create_deck_and_write_to_disk(deck_path: String, config: &Config) -> CliResult<()> {

--- a/seccardgame/src/game/create.rs
+++ b/seccardgame/src/game/create.rs
@@ -29,7 +29,10 @@ pub fn create_deck(config: &Config) -> Deck {
         "Enter number of turns after which attacks should be possible?",
         (event_card_count + attack_card_count + oopsie_card_count + lucky_card_count) / 4,
     );
-    let evaluation_cards = get_number_of_cards("Enter number of evaluation cards. The deck will be split into n + 1 parts and all parts except the first will contain an evaluation card. 0 disables them.", 0);
+    
+    let curent_card_count = event_card_count + attack_card_count + oopsie_card_count + lucky_card_count;
+    let eval_prompt = format!("Enter number of evaluation cards (max {}). The deck will be split into n + 1 parts and all parts except the first will contain an evaluation card. 0 disables them.", curent_card_count - 1);
+    let evaluation_cards = get_number_of_cards(eval_prompt.as_str(), 0);
 
     let deck_composition = DeckComposition {
         events: event_card_count as usize,

--- a/seccardgame/src/migrations/version_one.rs
+++ b/seccardgame/src/migrations/version_one.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use game_lib::cards::types::attack::AttackCard;
 use game_lib::cards::types::card_model::{Card, CardTrait};
+use game_lib::cards::types::evaluation::EvaluationCard;
 use game_lib::cards::types::event::EventCard;
 use game_lib::cards::types::lucky::LuckyCard;
 use game_lib::cards::types::oopsie::OopsieCard;
@@ -48,6 +49,9 @@ where
             }
             Card::Lucky(_) => {
                 Card::Lucky(serde_json::from_str::<LuckyCard>(content.as_str()).unwrap())
+            }
+            Card::Evaluation(_) => {
+                Card::Evaluation(EvaluationCard::default())
             }
         };
         fs::remove_file(card).unwrap();

--- a/seccardgame/src/migrations/version_three.rs
+++ b/seccardgame/src/migrations/version_three.rs
@@ -6,6 +6,7 @@ use serde_json::{json, Number, Value};
 
 use game_lib::cards::types::attack::AttackCard;
 use game_lib::cards::types::card_model::{Card, CardTrait};
+use game_lib::cards::types::evaluation::EvaluationCard;
 use game_lib::cards::types::event::EventCard;
 use game_lib::cards::types::lucky::LuckyCard;
 use game_lib::cards::types::oopsie::OopsieCard;
@@ -120,6 +121,7 @@ where
             Card::Attack(_) => Card::Attack(serde_json::from_value::<AttackCard>(v).unwrap()),
             Card::Oopsie(_) => Card::Oopsie(serde_json::from_value::<OopsieCard>(v).unwrap()),
             Card::Lucky(_) => Card::Lucky(serde_json::from_value::<LuckyCard>(v).unwrap()),
+            Card::Evaluation(_) => Card::Evaluation(EvaluationCard::default()),            
         };
         fs::remove_file(card).unwrap();
 


### PR DESCRIPTION
Closes #37 

Adds a question to the game start and asking for the number of evaluation cards.

Depending on the number of evaluation cards the deck is split into n + 1 chunks. Every chunk, expect the first, receives an evluation card and then gets shuffled. After that the chunks are combined again.

The evaluation card does not have a special text, actions or behaviour.

Also the insert mehtod was only tested manually and quickyl.
Also the maximal amount of evaluation cards is printed at the prompt but not validated, violation will lead to a panic.